### PR TITLE
Fix uninitialized constant TemporalTables::ArelTable::Nodes

### DIFF
--- a/lib/temporal_tables/arel_table.rb
+++ b/lib/temporal_tables/arel_table.rb
@@ -1,7 +1,7 @@
 module TemporalTables
   # This is required for eager_load to work in Rails 6.0
   module ArelTable
-    def create_join(to, constraint = nil, klass = Nodes::InnerJoin)
+    def create_join(to, constraint = nil, klass = Arel::Nodes::InnerJoin)
       join = super
       if at_value = Thread.current[:at_time]
         join = join.

--- a/lib/temporal_tables/temporal_adapter.rb
+++ b/lib/temporal_tables/temporal_adapter.rb
@@ -10,7 +10,12 @@ module TemporalTables
           block.call t
 
           if TemporalTables.add_updated_by_field && !skip_table
-            t.column :updated_by, TemporalTables.updated_by_type
+            updated_by_already_exists = t.columns.any? { |c| c.name == "updated_by" }
+            if updated_by_already_exists
+              puts "consider adding #{table_name} to TemporalTables skip_table"
+            else
+              t.column :updated_by, TemporalTables.updated_by_type
+            end
           end
         end
 

--- a/temporal_tables.gemspec
+++ b/temporal_tables.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "rails", ">= 5.0", "<= 6.0"
+  gem.add_dependency "rails", ">= 5.0", "< 6.1"
   gem.add_development_dependency "rspec", "~> 3.4"
   gem.add_development_dependency "combustion", "~> 0.9.1"
   gem.add_development_dependency "gemika"


### PR DESCRIPTION
Tried to update to Rails 6, but have been getting the following error
```
NameError:
  uninitialized constant TemporalTables::ArelTable::Nodes
```