### PR TITLE
Allow use of non-integer id's on temporal tables

### DIFF
--- a/lib/temporal_tables/temporal_adapter.rb
+++ b/lib/temporal_tables/temporal_adapter.rb
@@ -27,7 +27,9 @@ module TemporalTables
 
     def add_temporal_table(table_name, options = {})
       create_table temporal_name(table_name), options.merge(id: false, primary_key: "history_id", temporal_bypass: true) do |t|
-        t.integer   :id
+        if options[:id] != false
+          t.column :id, options.fetch(:id, :integer)
+        end
         t.datetime :eff_from, :null => false, limit: 6
         t.datetime :eff_to,   :null => false, limit: 6, :default => "9999-12-31"
 

--- a/temporal_tables.gemspec
+++ b/temporal_tables.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "rails", ">= 5.0", "<= 6.0"
+  gem.add_dependency "rails", ">= 5.0", "< 6.1"
   gem.add_development_dependency "rspec", "~> 3.4"
   gem.add_development_dependency "combustion", "~> 0.9.1"
   gem.add_development_dependency "gemika"


### PR DESCRIPTION
I'm using UUID's for the id column. This seemed to work in 0.6.4, but, alas, no longer does.