### PR TITLE
Allow other types (enum)

### DIFF
--- a/lib/temporal_tables/temporal_adapter.rb
+++ b/lib/temporal_tables/temporal_adapter.rb
@@ -40,9 +40,9 @@ module TemporalTables
           next if c.name == 'id'
 
           if t.respond_to?(c.type)
-            options = { limit: c.limit }
-            options[:enum_type] = c.sql_type_metadata.sql_type if c.type == :enum
-            t.send c.type, c.name, **options
+            column_options = { limit: c.limit }
+            column_options[:enum_type] = c.sql_type_metadata.sql_type if c.type == :enum
+            t.send c.type, c.name, **column_options
           else          
             t.column c.name, c.sql_type_metadata.sql_type
           end
@@ -55,7 +55,7 @@ module TemporalTables
         end
       end
 
-      add_index temporal_name(table_name), [:id, :eff_to]
+      add_index temporal_name(table_name), [:id, :eff_to] if options[:id] != false
       create_temporal_triggers table_name
       create_temporal_indexes table_name
     end

--- a/lib/temporal_tables/temporal_adapter.rb
+++ b/lib/temporal_tables/temporal_adapter.rb
@@ -39,7 +39,13 @@ module TemporalTables
         columns(table_name).each do |c|
           next if c.name == 'id'
 
-          t.send c.type, c.name, limit: c.limit
+          if t.respond_to?(c.type)
+            options = { limit: c.limit }
+            options[:enum_type] = c.sql_type_metadata.sql_type if c.type == :enum
+            t.send c.type, c.name, **options
+          else          
+            t.column c.name, c.sql_type_metadata.sql_type
+          end
         end
       end
 

--- a/lib/temporal_tables/temporal_adapter_six_oh.rb
+++ b/lib/temporal_tables/temporal_adapter_six_oh.rb
@@ -55,7 +55,7 @@ module TemporalTables
         end
       end
 
-      add_index temporal_name(table_name), [:id, :eff_to]
+      add_index temporal_name(table_name), [:id, :eff_to] if options[:id] != false
       create_temporal_triggers table_name
       create_temporal_indexes table_name
     end

--- a/lib/temporal_tables/temporal_adapter_six_oh.rb
+++ b/lib/temporal_tables/temporal_adapter_six_oh.rb
@@ -41,7 +41,11 @@ module TemporalTables
         columns(table_name).each do |c|
           next if c.name == 'id'
 
-          t.send c.type, c.name, limit: c.limit
+          if t.respond_to?(c.type)
+            t.send c.type, c.name, limit: c.limit
+          else
+            t.column c.name, c.sql_type_metadata.sql_type
+          end
         end
       end
 

--- a/spec/basic_history_spec.rb
+++ b/spec/basic_history_spec.rb
@@ -161,6 +161,12 @@ describe Person do
       cat.lives.create started_at: Time.zone.now
     end
 
+    # The following tests enum type columns for postgres
+    it 'breed is set correctly' do
+      expect(cat.breed).to eq('ragdoll')
+      expect(cat.history.last.breed).to eq('ragdoll')
+    end
+
     it 'shows one life at the beginning' do
       expect(cat.history.at(@init_time).last.lives.size).to eq(1)
     end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -7,7 +7,12 @@ rescue NameError
 end
 
 ActiveRecord::Schema.define do
-  enable_extension 'pgcrypto' if postgres
+  if postgres
+    enable_extension 'pgcrypto' 
+    execute <<-SQL
+      CREATE TYPE cat_breed AS ENUM ('ragdoll', 'persian', 'sphynx');
+    SQL
+  end
 
   create_table :covens, force: true do |t|
     t.string :name
@@ -36,6 +41,7 @@ ActiveRecord::Schema.define do
   create_table :cats, id: (postgres ? :uuid : :integer), temporal: true, force: true do |t|
     t.string :name
     t.string :color
+    t.column :breed, (postgres ? :cat_breed : :string), null: false, default: 'ragdoll'
   end
 
   create_table :cat_lives, id: (postgres ? :uuid : :integer), temporal: true do |t|


### PR DESCRIPTION
I don't know if this solution makes sense, if it makes more sense to split off an adapter for Rails 7, or if it makes sense to use `t.column` regardless of the Rails version and type. Let me know and I can update the PR