### PR TITLE
Improvements

### DIFF
--- a/lib/temporal_tables/connection_adapters/mysql_adapter.rb
+++ b/lib/temporal_tables/connection_adapters/mysql_adapter.rb
@@ -9,7 +9,7 @@ module TemporalTables
         execute "drop trigger #{table_name}_ad"
       end
 
-      def create_temporal_triggers(table_name) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      def create_temporal_triggers(table_name, primary_key) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         column_names = columns(table_name).map(&:name)
 
         execute "drop trigger if exists #{table_name}_ai"
@@ -33,7 +33,7 @@ module TemporalTables
             set @current_time = utc_timestamp(6);
 
             update #{temporal_name(table_name)} set eff_to = @current_time
-            where id = new.id
+            where #{primary_key} = new.#{primary_key}
             and eff_to = '9999-12-31';
 
             insert into #{temporal_name(table_name)} (#{column_names.join(', ')}, eff_from)
@@ -50,7 +50,7 @@ module TemporalTables
             set @current_time = utc_timestamp(6);
 
             update #{temporal_name(table_name)} set eff_to = @current_time
-            where id = old.id
+            where #{primary_key} = old.#{primary_key}
             and eff_to = '9999-12-31';
 
           end

--- a/lib/temporal_tables/connection_adapters/postgresql_adapter.rb
+++ b/lib/temporal_tables/connection_adapters/postgresql_adapter.rb
@@ -9,7 +9,7 @@ module TemporalTables
         execute "drop trigger #{table_name}_ad on #{table_name}"
       end
 
-      def create_temporal_triggers(table_name) # rubocop:disable Metrics/MethodLength
+      def create_temporal_triggers(table_name, primary_key) # rubocop:disable Metrics/MethodLength
         column_names = columns(table_name).map(&:name)
 
         execute %{
@@ -39,7 +39,7 @@ module TemporalTables
               cur_time := localtimestamp;
 
               update #{temporal_name(table_name)} set eff_to = cur_time
-              where id = new.id
+              where #{primary_key} = new.#{primary_key}
                 and eff_to = '9999-12-31';
 
               insert into #{temporal_name(table_name)} (#{column_list(column_names)}, eff_from)
@@ -62,7 +62,7 @@ module TemporalTables
               cur_time := localtimestamp;
 
               update #{temporal_name(table_name)} set eff_to = cur_time
-              where id = old.id
+              where #{primary_key} = old.#{primary_key}
                 and eff_to = '9999-12-31';
 
               return null;

--- a/lib/temporal_tables/history_hook.rb
+++ b/lib/temporal_tables/history_hook.rb
@@ -45,7 +45,7 @@ module TemporalTables
     def history
       clazz = is_a?(TemporalTables::TemporalClass) ? self.class : self.class.history
       oid = is_a?(TemporalTables::TemporalClass) ? orig_class.primary_key : self.class.primary_key
-      clazz.unscoped.where(id: attributes[oid]).order(:eff_from)
+      clazz.unscoped.where(oid => attributes[oid]).order(:eff_from)
     end
   end
 end

--- a/lib/temporal_tables/temporal_adapter.rb
+++ b/lib/temporal_tables/temporal_adapter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'digest'
+
 module TemporalTables
   module TemporalAdapter # rubocop:disable Metrics/ModuleLength
     def create_table(table_name, **options, &block) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
@@ -32,14 +34,22 @@ module TemporalTables
         temporal_name(table_name),
         **options.merge(id: false, primary_key: 'history_id', temporal_bypass: true)
       ) do |t|
-        t.column :id, options.fetch(:id, :integer) if options[:id] != false
         t.datetime :eff_from, null: false, limit: 6
         t.datetime :eff_to,   null: false, limit: 6, default: '9999-12-31'
 
         columns(table_name).each do |c|
-          next if c.name == 'id'
+          column_options = { limit: c.limit }
+          column_type = c.type
+          if column_type == :enum
+            enum_type = c.sql_type_metadata.sql_type
+            if t.respond_to?(:enum)
+              column_options[:enum_type] = enum_type
+            else
+              column_type = enum_type
+            end
+          end
 
-          t.send c.type, c.name, limit: c.limit
+          t.column c.name, column_type, **column_options
         end
       end
 
@@ -49,8 +59,13 @@ module TemporalTables
         end
       end
 
-      add_index temporal_name(table_name), [:id, :eff_to]
-      create_temporal_triggers table_name
+      original_primary_key = original_primary_key(table_name)
+      temporal_table_index_name = index_name(temporal_name(table_name), [original_primary_key, :eff_to])
+      if temporal_table_index_name.length > index_name_length
+        temporal_table_index_name = truncated_index_name(temporal_table_index_name)
+      end
+      add_index temporal_name(table_name), [original_primary_key, :eff_to], name: temporal_table_index_name
+      create_temporal_triggers table_name, original_primary_key
       create_temporal_indexes table_name
     end
 
@@ -75,7 +90,7 @@ module TemporalTables
       return unless table_exists?(temporal_name(name))
 
       super(temporal_name(name), temporal_name(new_name))
-      create_temporal_triggers new_name
+      create_temporal_triggers new_name, original_primary_key(table_name)
     end
 
     def add_column(table_name, column_name, type, **options)
@@ -84,7 +99,7 @@ module TemporalTables
       return unless table_exists?(temporal_name(table_name))
 
       super temporal_name(table_name), column_name, type, **options
-      create_temporal_triggers table_name
+      create_temporal_triggers table_name, original_primary_key(table_name)
     end
 
     def remove_columns(table_name, *column_names, **options)
@@ -93,7 +108,7 @@ module TemporalTables
       return unless table_exists?(temporal_name(table_name))
 
       super temporal_name(table_name), *column_names, **options
-      create_temporal_triggers table_name
+      create_temporal_triggers table_name, original_primary_key(table_name)
     end
 
     def remove_column(table_name, column_name, type = nil, **options)
@@ -102,7 +117,7 @@ module TemporalTables
       return unless table_exists?(temporal_name(table_name))
 
       super temporal_name(table_name), column_name, type, **options
-      create_temporal_triggers table_name
+      create_temporal_triggers table_name, original_primary_key(table_name)
     end
 
     def change_column(table_name, column_name, type, **options)
@@ -120,7 +135,7 @@ module TemporalTables
       return unless table_exists?(temporal_name(table_name))
 
       super temporal_name(table_name), column_name, new_column_name
-      create_temporal_triggers table_name
+      create_temporal_triggers table_name, original_primary_key(table_name)
     end
 
     def add_index(table_name, column_name, **options)
@@ -173,13 +188,27 @@ module TemporalTables
       raise NotImplementedError, 'drop_temporal_triggers is not implemented'
     end
 
-    # It's important not to increase the length of the returned string.
+    # Index names max out at 63 characters. If appending _h to the index name would surpass that limit,
+    # we can trim the index name and append a deterministically generated 5 character hash as well as _h.
     def temporal_index_name(index_name)
-      index_name.to_s.sub(/^index/, 'ind_h').sub(/_ix(\d+)$/, '_hi\1')
+      "#{index_name.length < 62 ? index_name : truncated_index_name(index_name, 2)}_h"
+    end
+
+    def truncated_index_name(index_name, required_padding = 0)
+      max_length = index_name_length - required_padding
+      index_name_hash = Digest::SHA1.base64digest(index_name.to_s)[0, 5]
+      "#{index_name[0, max_length - 6]}_#{index_name_hash}"
     end
 
     def temporal_index_exists?(table_name, index_name)
       index_name_exists?(temporal_name(table_name), index_name)
+    end
+
+    def original_primary_key(table_name)
+      original_primary_key = primary_key(table_name)
+      raise 'temporal_adapter requires that the table has a single primary key' unless original_primary_key.is_a? String
+
+      original_primary_key
     end
   end
 end

--- a/lib/temporal_tables/temporal_class.rb
+++ b/lib/temporal_tables/temporal_class.rb
@@ -90,7 +90,7 @@ module TemporalTables
     end
 
     def orig_obj
-      @orig_obj ||= orig_class.find_by id: orig_id
+      @orig_obj ||= orig_class.find_by(orig_class.primary_key => orig_id)
     end
 
     def prev

--- a/lib/temporal_tables/version.rb
+++ b/lib/temporal_tables/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TemporalTables
-  VERSION = '1.0.3'
+  VERSION = '1.1.0'
 end

--- a/spec/internal/app/models/dog.rb
+++ b/spec/internal/app/models/dog.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Dog < ActiveRecord::Base
+  self.primary_key = :dog_id
+end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -7,7 +7,12 @@ rescue NameError
 end
 
 ActiveRecord::Schema.define do
-  enable_extension 'pgcrypto' if postgres
+  if postgres
+    enable_extension 'pgcrypto'
+    execute <<-SQL
+      CREATE TYPE cat_breed AS ENUM ('ragdoll', 'persian', 'sphynx');
+    SQL
+  end
 
   create_table :covens, force: true do |t|
     t.string :name
@@ -36,6 +41,7 @@ ActiveRecord::Schema.define do
   create_table :cats, id: (postgres ? :uuid : :integer), temporal: true, force: true do |t|
     t.string :name
     t.string :color
+    t.column :breed, (postgres ? :cat_breed : :string), null: false, default: 'ragdoll'
   end
 
   create_table :cat_lives, id: (postgres ? :uuid : :integer), temporal: true do |t|
@@ -43,5 +49,15 @@ ActiveRecord::Schema.define do
     t.timestamp :started_at
     t.timestamp :ended_at
     t.string :death_reason
+  end
+
+  create_table :dogs, primary_key: 'dog_id', temporal: true do |t|
+    t.string :name
+  end
+  add_index :dogs, :name, name: 'name_index_with_a_name_that_happens_to_be_exactly_63_chars_long'
+  remove_index :dogs, name: :name_index_with_a_name_that_happens_to_be_exactly_63_chars_long
+
+  create_table :a_very_very_very_very_very_long_table_name, temporal: true do |t|
+    t.string :name
   end
 end


### PR DESCRIPTION
This PR makes a few improvements (assuming these will work)

- Allow enum columns
- Allow PKs with names other than `id`
- Allow non-standard index names

Breaking change:
  Every table created as or converted to a temporal table must have a single-column PK. I think this was implicitly true before, but now it's enforced.