### PR TITLE
Correct eff_to boundary on history queries

### DIFF
--- a/lib/temporal_tables.rb
+++ b/lib/temporal_tables.rb
@@ -12,6 +12,7 @@ require 'temporal_tables/association_extensions'
 require 'temporal_tables/preloader_extensions'
 require 'temporal_tables/reflection_extensions'
 require 'temporal_tables/arel_table'
+require 'temporal_tables/constants'
 require 'temporal_tables/version'
 
 module TemporalTables

--- a/lib/temporal_tables/arel_table.rb
+++ b/lib/temporal_tables/arel_table.rb
@@ -9,7 +9,7 @@ module TemporalTables
       if at_value
         join =
           join
-          .and(to[:eff_to].gt(at_value))
+          .and(to[:eff_to].gt(at_value).or(to[:eff_to].eq('9999-12-31')))
           .and(to[:eff_from].lteq(at_value))
       end
       join

--- a/lib/temporal_tables/arel_table.rb
+++ b/lib/temporal_tables/arel_table.rb
@@ -9,7 +9,7 @@ module TemporalTables
       if at_value
         join =
           join
-          .and(to[:eff_to].gt(at_value).or(to[:eff_to].eq('9999-12-31')))
+          .and(to[:eff_to].gt(at_value).or(to[:eff_to].eq(TemporalTables::END_OF_TIME)))
           .and(to[:eff_from].lteq(at_value))
       end
       join

--- a/lib/temporal_tables/arel_table.rb
+++ b/lib/temporal_tables/arel_table.rb
@@ -9,7 +9,7 @@ module TemporalTables
       if at_value
         join =
           join
-          .and(to[:eff_to].gteq(at_value))
+          .and(to[:eff_to].gt(at_value))
           .and(to[:eff_from].lteq(at_value))
       end
       join

--- a/lib/temporal_tables/connection_adapters/mysql_adapter.rb
+++ b/lib/temporal_tables/connection_adapters/mysql_adapter.rb
@@ -34,7 +34,7 @@ module TemporalTables
 
             update #{temporal_name(table_name)} set eff_to = @current_time
             where #{primary_key} = new.#{primary_key}
-            and eff_to = '9999-12-31';
+            and eff_to = '#{TemporalTables::END_OF_TIME}';
 
             insert into #{temporal_name(table_name)} (#{column_names.join(', ')}, eff_from)
             values (#{column_names.collect { |c| "new.#{c}" }.join(', ')}, @current_time);
@@ -51,7 +51,7 @@ module TemporalTables
 
             update #{temporal_name(table_name)} set eff_to = @current_time
             where #{primary_key} = old.#{primary_key}
-            and eff_to = '9999-12-31';
+            and eff_to = '#{TemporalTables::END_OF_TIME}';
 
           end
         }

--- a/lib/temporal_tables/connection_adapters/postgresql_adapter.rb
+++ b/lib/temporal_tables/connection_adapters/postgresql_adapter.rb
@@ -40,7 +40,7 @@ module TemporalTables
 
               update #{temporal_name(table_name)} set eff_to = cur_time
               where #{primary_key} = new.#{primary_key}
-                and eff_to = '9999-12-31';
+                and eff_to = '#{TemporalTables::END_OF_TIME}';
 
               insert into #{temporal_name(table_name)} (#{column_list(column_names)}, eff_from)
               values (#{column_names.collect { |c| "new.#{c}" }.join(', ')}, cur_time);
@@ -63,7 +63,7 @@ module TemporalTables
 
               update #{temporal_name(table_name)} set eff_to = cur_time
               where #{primary_key} = old.#{primary_key}
-                and eff_to = '9999-12-31';
+                and eff_to = '#{TemporalTables::END_OF_TIME}';
 
               return null;
             end

--- a/lib/temporal_tables/constants.rb
+++ b/lib/temporal_tables/constants.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module TemporalTables
+  END_OF_TIME = '9999-12-31'
+end

--- a/lib/temporal_tables/temporal_adapter.rb
+++ b/lib/temporal_tables/temporal_adapter.rb
@@ -35,7 +35,7 @@ module TemporalTables
         **options.merge(id: false, primary_key: 'history_id', temporal_bypass: true)
       ) do |t|
         t.datetime :eff_from, null: false, limit: 6
-        t.datetime :eff_to,   null: false, limit: 6, default: '9999-12-31'
+        t.datetime :eff_to,   null: false, limit: 6, default: TemporalTables::END_OF_TIME
 
         columns(table_name).each do |c|
           column_options = { limit: c.limit }

--- a/lib/temporal_tables/temporal_adapter_six_oh.rb
+++ b/lib/temporal_tables/temporal_adapter_six_oh.rb
@@ -37,7 +37,7 @@ module TemporalTables
         **options.merge(id: false, primary_key: 'history_id', temporal_bypass: true)
       ) do |t|
         t.datetime :eff_from, null: false, limit: 6
-        t.datetime :eff_to,   null: false, limit: 6, default: '9999-12-31'
+        t.datetime :eff_to,   null: false, limit: 6, default: TemporalTables::END_OF_TIME
 
         columns(table_name).each do |c|
           column_type = c.type == :enum ? c.sql_type_metadata.sql_type : c.type

--- a/lib/temporal_tables/temporal_class.rb
+++ b/lib/temporal_tables/temporal_class.rb
@@ -77,7 +77,7 @@ module TemporalTables
       # An object at a given time should fall within the range, excluding the effective end date.
       # However, when using '9999-12-31', this is effectively infinity and should not be excluded.
       def build_temporal_constraint(at_value)
-        (arel_table[:eff_to].gt(at_value).or(arel_table[:eff_to].eq('9999-12-31'))).and(
+        (arel_table[:eff_to].gt(at_value).or(arel_table[:eff_to].eq(TemporalTables::END_OF_TIME))).and(
           arel_table[:eff_from].lteq(at_value)
         )
       end

--- a/lib/temporal_tables/temporal_class.rb
+++ b/lib/temporal_tables/temporal_class.rb
@@ -75,7 +75,7 @@ module TemporalTables
       delegate :descends_from_active_record?, to: :superclass
 
       def build_temporal_constraint(at_value)
-        arel_table[:eff_to].gteq(at_value).and(
+        arel_table[:eff_to].gt(at_value).and(
           arel_table[:eff_from].lteq(at_value)
         )
       end

--- a/lib/temporal_tables/temporal_class.rb
+++ b/lib/temporal_tables/temporal_class.rb
@@ -74,8 +74,10 @@ module TemporalTables
 
       delegate :descends_from_active_record?, to: :superclass
 
+      # An object at a given time should fall within the range, excluding the effective end date.
+      # However, when using '9999-12-31', this is effectively infinity and should not be excluded.
       def build_temporal_constraint(at_value)
-        arel_table[:eff_to].gt(at_value).and(
+        (arel_table[:eff_to].gt(at_value).or(arel_table[:eff_to].eq('9999-12-31'))).and(
           arel_table[:eff_from].lteq(at_value)
         )
       end

--- a/lib/temporal_tables/version.rb
+++ b/lib/temporal_tables/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TemporalTables
-  VERSION = '1.1.0'
+  VERSION = '2.0.0'
 end

--- a/spec/basic_history_spec.rb
+++ b/spec/basic_history_spec.rb
@@ -195,6 +195,12 @@ describe Person do
         expect(fido.orig_obj.name).to eq('Max')
       end
 
+      it 'at the exact time of the name change, the dog should not be both Max and Fido' do
+        dog_at_moment_of_name_change = dog.history.at(dog.history.last.eff_from)
+        expect(dog_at_moment_of_name_change.count).to eq(1)
+        expect(dog_at_moment_of_name_change.first.name).to eq('Max')
+      end
+
       context 'Max is rehomed' do
         before do
           dog.destroy!

--- a/spec/basic_history_spec.rb
+++ b/spec/basic_history_spec.rb
@@ -90,10 +90,10 @@ describe Person do
         where = sql[4]
 
         expect(from.scan(/.warts_h.\..eff_from./i).count).to eq(1)
-        expect(from.scan(/.warts_h.\..eff_to./i).count).to eq(1)
+        expect(from.scan(/.warts_h.\..eff_to./i).count).to eq(2)
 
         expect(where.scan(/.people_h.\..eff_from./i).count).to eq(1)
-        expect(where.scan(/.people_h.\..eff_to./i).count).to eq(1)
+        expect(where.scan(/.people_h.\..eff_to./i).count).to eq(2)
         expect(where.scan(/.warts_h.\..eff_from./i).count).to eq(0)
         expect(where.scan(/.warts_h.\..eff_to./i).count).to eq(0)
       end


### PR DESCRIPTION
Maybe it was intended to work this way, but in my opinion, when querying the history, the "effective to" boundary should be exclusive, and querying for the object `at` the exact time that a change occurred should only return the state of the object after the change was made, not both before and after.

On that note, should `at` return a single record, rather than an array?

Not sure if this could use more tests around associations or anything else. I'm open to adding more tests if there are suggestions.

Also, I bumped the major version since this would be a breaking change. I could also change this to be some sort of config option if you want to avoid breaking the current behavior.