### PR TITLE
Get class directly

### DIFF
--- a/lib/temporal_tables/temporal_class.rb
+++ b/lib/temporal_tables/temporal_class.rb
@@ -33,7 +33,7 @@ module TemporalTables
 
             # Calling .history here will ensure that the history class
             # for this association is created and initialized
-            clazz = association.class_name.constantize.history
+            clazz = association.klass.history
 
             # Recreate the association, updating it to point at the
             # history class.  The foreign key is explicitly set since it's

--- a/spec/basic_history_spec.rb
+++ b/spec/basic_history_spec.rb
@@ -215,3 +215,17 @@ describe Person do
     end
   end
 end
+
+describe Bird do
+  context 'when a bird and nest exist' do
+    let(:bird) { Bird.create name: 'Sam' }
+    let(:nest) { Bird::Nest.create bird: bird, height: 100 }
+
+    it 'can create instance of class with nested class name with history entries' do
+      expect(bird).not_to be_nil
+      expect(nest).not_to be_nil
+      expect(bird.history.first).not_to be_nil
+      expect(nest.history.first).not_to be_nil
+    end
+  end
+end

--- a/spec/internal/app/models/bird.rb
+++ b/spec/internal/app/models/bird.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Bird < ActiveRecord::Base
+  has_one :nest, inverse_of: :bird
+end

--- a/spec/internal/app/models/bird/nest.rb
+++ b/spec/internal/app/models/bird/nest.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Bird::Nest < ActiveRecord::Base
+  self.table_name = 'nests'
+  belongs_to :bird, inverse_of: :nest
+end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -60,4 +60,13 @@ ActiveRecord::Schema.define do
   create_table :a_very_very_very_very_very_long_table_name, temporal: true do |t|
     t.string :name
   end
+
+  create_table :birds, id: (postgres ? :uuid : :integer), temporal: true, force: true do |t|
+    t.string :name
+  end
+
+  create_table :nests, id: (postgres ? :uuid : :integer), temporal: true do |t|
+    t.belongs_to :bird, type: (postgres ? :uuid : :integer)
+    t.integer :height
+  end
 end


### PR DESCRIPTION
Was getting an error because the association in class `A` was `has_one :b`, but the class was actually `A:B`, so when it tried to constantize just `B` it threw an error that `B` didn't exist.

Not sure if this is the best solution, or if there's a better one. As a workaround, I added `A:B` explicitly as the `class_name` for the association