### PR TITLE
add missing index options

### DIFF
--- a/lib/temporal_tables/temporal_adapter.rb
+++ b/lib/temporal_tables/temporal_adapter.rb
@@ -172,7 +172,9 @@ module TemporalTables
           # exclude unique constraints for temporal tables
           name: index_name,
           length: index.lengths,
-          order: index.orders
+          order: index.orders,
+          using: index.using,
+          opclass: index.opclasses
         )
       end
     end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -75,7 +75,8 @@ ActiveRecord::Schema.define do
     create_table :hamsters, id: false do |t|
       t.column :uuid, :uuid, default: 'gen_random_uuid()'
       t.string :name
-      t.index "((uuid)::text || ' '::text || (name)::text) gin_trgm_ops", name: :uuid_name_index_with_opclass_and_using, opclass: :gin_trgm_ops, using: :gin
+      t.index "((uuid)::text || ' '::text || (name)::text) gin_trgm_ops",
+              name: :uuid_name_index_with_opclass_and_using, opclass: :gin_trgm_ops, using: :gin
     end
     execute 'ALTER TABLE hamsters ADD PRIMARY KEY (uuid);'
     add_temporal_table :hamsters

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -9,6 +9,7 @@ end
 ActiveRecord::Schema.define do
   if postgres
     enable_extension 'pgcrypto'
+    enable_extension 'pg_trgm'
     execute <<-SQL
       CREATE TYPE cat_breed AS ENUM ('ragdoll', 'persian', 'sphynx');
     SQL
@@ -74,6 +75,7 @@ ActiveRecord::Schema.define do
     create_table :hamsters, id: false do |t|
       t.column :uuid, :uuid, default: 'gen_random_uuid()'
       t.string :name
+      t.index "((uuid)::text || ' '::text || (name)::text) gin_trgm_ops", name: :uuid_name_index_with_opclass_and_using, opclass: :gin_trgm_ops, using: :gin
     end
     execute 'ALTER TABLE hamsters ADD PRIMARY KEY (uuid);'
     add_temporal_table :hamsters


### PR DESCRIPTION
for example if you have such an index:

```rb
t.index ["note"], name: "index_users_on_note", opclass: :gin_trgm_ops, using: :gin
```

it needs the `opclass` and `using` option to be successfully created

EDIT: actually the first example works without this patch but such an index fails:

```rb
t.index "((uuid)::text || ' '::text || (name)::text) gin_trgm_ops", opclass: :gin_trgm_ops, using: :gin
```

---

~~Didn't manage to get the specs running locally to add a spec for it yet, though.~~ Index added to test app.