### PR TITLE
make sure to remove updated_by when removing temporal column

### DIFF
--- a/lib/temporal_tables/temporal_adapter.rb
+++ b/lib/temporal_tables/temporal_adapter.rb
@@ -76,9 +76,9 @@ module TemporalTables
       drop_temporal_triggers table_name
       drop_table temporal_name(table_name)
 
-      if TemporalTables.add_updated_by_field && column_exists?(table_name, :updated_by)
-        remove_column table_name, :updated_by
-      end
+      return unless TemporalTables.add_updated_by_field && column_exists?(table_name, :updated_by)
+
+      remove_column table_name, :updated_by
     end
 
     def drop_table(table_name, **options)

--- a/lib/temporal_tables/temporal_adapter.rb
+++ b/lib/temporal_tables/temporal_adapter.rb
@@ -75,6 +75,10 @@ module TemporalTables
 
       drop_temporal_triggers table_name
       drop_table temporal_name(table_name)
+
+      if TemporalTables.add_updated_by_field && column_exists?(table_name, :updated_by)
+        remove_column table_name, :updated_by
+      end
     end
 
     def drop_table(table_name, **options)


### PR DESCRIPTION
since it is created by us it should be removed

it is a little bit delicate to do this since it modifies original tables, but we assume the column was created by us