### PR TITLE
update github ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,28 @@ on:
       - master
 
 jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.3"]
+        gemfile:
+          - "gemfiles/Gemfile.7.1.pg"
+    env:
+      BUNDLE_GEMFILE: ${{github.workspace}}/${{matrix.gemfile }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{ matrix.ruby }}"
+      - name: Bundle
+        run: bundle install
+
+      - name: Run Rubocop
+        run: bundle exec rubocop
+
   tests:
     runs-on: ubuntu-latest
 
@@ -51,9 +73,6 @@ jobs:
           gem install bundler:2.4.10
           bundle install
 
-      - name: Run Rubocop
-        run: bundle exec rubocop
-
       - name: Run Tests
         env:
           PGHOST: localhost
@@ -61,7 +80,9 @@ jobs:
         run: bundle exec rspec
 
   publish:
-    needs: [tests]
+    needs:
+      - rubocop
+      - tests
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - '**'
+      - "**"
     tags:
       - "v*.*.*"
   pull_request:
@@ -16,11 +16,13 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11.5
+        image: postgres:16
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       mysql:
-        image: mysql:8.0
+        image: mysql:8
         env:
           MYSQL_ROOT_PASSWORD: password
         ports: ["3306:3306"]
@@ -29,8 +31,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0.6", "3.1.4", "3.2.2"]
-        gemfile: 
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        gemfile:
           - "gemfiles/Gemfile.6.1.mysql"
           - "gemfiles/Gemfile.6.1.pg"
           - "gemfiles/Gemfile.7.0.mysql"
@@ -40,23 +42,23 @@ jobs:
     env:
       BUNDLE_GEMFILE: ${{github.workspace}}/${{matrix.gemfile }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: "${{ matrix.ruby }}"
-    - name: Bundle
-      run: |
-        gem install bundler:2.4.10
-        bundle install
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{ matrix.ruby }}"
+      - name: Bundle
+        run: |
+          gem install bundler:2.4.10
+          bundle install
 
-    - name: Run Rubocop
-      run: bundle exec rubocop
+      - name: Run Rubocop
+        run: bundle exec rubocop
 
-    - name: Run Tests
-      env:
-        PGHOST: localhost
-        PGUSER: postgres
-      run: bundle exec rspec
+      - name: Run Tests
+        env:
+          PGHOST: localhost
+          PGUSER: postgres
+        run: bundle exec rspec
 
   publish:
     needs: [tests]
@@ -68,9 +70,9 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2.2"
+          ruby-version: "3.3"
           bundler-cache: true
       - uses: rubygems/release-gem@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,9 +69,7 @@ jobs:
         with:
           ruby-version: "${{ matrix.ruby }}"
       - name: Bundle
-        run: |
-          gem install bundler:2.4.10
-          bundle install
+        run: bundle install
 
       - name: Run Tests
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,13 +38,13 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: ${{ endsWith(matrix.gemfile, '.pg') && 'postgres:16' || '' }}
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       mysql:
-        image: mysql:8
+        image: ${{ endsWith(matrix.gemfile, '.mysql') && 'mysql:8' || '' }}
         env:
           MYSQL_ROOT_PASSWORD: password
         ports: ["3306:3306"]


### PR DESCRIPTION
- use latest checkout action
- use latest ruby versions
- use latest postgresql and mysql versions
- remove unneeded bundler version install
- only start services when needed