### PR TITLE
Correctly reset thread variable `at_time` even on exception

### DIFF
--- a/lib/temporal_tables/relation_extensions.rb
+++ b/lib/temporal_tables/relation_extensions.rb
@@ -33,13 +33,15 @@ module TemporalTables
 
     def threadify_at
       if at_value && !Thread.current[:at_time]
-        Thread.current[:at_time] = at_value
-        result = yield
-        Thread.current[:at_time] = nil
+        begin
+          Thread.current[:at_time] = at_value
+          yield
+        ensure
+          Thread.current[:at_time] = nil
+        end
       else
-        result = yield
+        yield
       end
-      result
     end
 
     def limited_ids_for(*args)

--- a/spec/basic_history_spec.rb
+++ b/spec/basic_history_spec.rb
@@ -62,6 +62,15 @@ describe Person do
       end
     end
 
+    describe 'creating a join query' do
+      it 'correctly joins even after generating sql has failed before' do
+        expect { Person.history.at(100.years.ago).joins(:warts).where(x: proc {}).to_sql }.to raise_error(TypeError)
+
+        # it still fetches the history correctly
+        expect(Person.history.at(Time.current).joins(:warts)).to be_present
+      end
+    end
+
     describe 'when preloading associations' do
       let(:orig_emily) { emily.history.at(@init_time).preload(:warts).first }
 


### PR DESCRIPTION
`Thread.current[:at_time]` was set but not reset if the `yield` raised an error. This led to a stale `at_time` being used in unrelated queries on the same thread.